### PR TITLE
Fix vmotion ping

### DIFF
--- a/HXTool.py
+++ b/HXTool.py
@@ -1106,13 +1106,29 @@ def network_check(ip):
                     elif vmkip != "":
                         try:
                             #cmd = "vmkping -I {} -c 3 -d -s {} {} -S vmotion".format(vmknode, mtu, vmkip)
+
+                            # The first ping in a while might drop a
+                            # few packets while the ARP cache
+                            # populates, particularly with an
+                            # aggressive timeout.  Rather than attempt
+                            # to fix the pingstatus() parser, which
+                            # expects 0% packet loss, we will run the
+                            # ping command twice to pre-populate the
+                            # ARP cache.
+                            cmd = "vmkping -I {} -c 1 {}".format(vmknode, vmkip)
+                            op = execmd(cmd)
+
                             cmd = "vmkping -I {} -c 3 -d -s {} -i 0.05 {}".format(vmknode, mtu, vmkip)
                             op = execmd(cmd)
+
                             pst = pingstatus(op)
                             opd.update({cmd: pst})
                             allvmkpingchk.append(pst)
                         except Exception:
                             pass
+                        pass
+                    pass
+                pass
             # Check ESXi Version
             try:
                 cmd = "vmware -l"

--- a/HXTool.py
+++ b/HXTool.py
@@ -1109,9 +1109,10 @@ def network_check(ip):
 
                             # The first ping in a while might drop a
                             # few packets while the ARP cache
-                            # populates, particularly with an
-                            # aggressive timeout.  Rather than attempt
-                            # to fix the pingstatus() parser, which
+                            # populates if vMotion has been idle,
+                            # particularly with an aggressive timeout
+                            # as we have here.  Rather than attempt to
+                            # fix the pingstatus() parser, which
                             # expects 0% packet loss, we will run the
                             # ping command twice to pre-populate the
                             # ARP cache.


### PR DESCRIPTION
This is a simple proposal to fix the vmotion ping failure problem.   The first few vmotion pings often fail on a cluster node that has been idle.  If you run the HXTool.py script again, it works fine.   Assuming it takes a moment to populate the ARP cache, the aggressive nature of the timeout and the short count on the ping may cause a packet or two to be dropped.. The parser that checks the ping response expects 0% packet loss, hence it fails the test.  Rather than re-write the pingstatus() parser, it's easier to just run the test twice - once with a normal timeout and normal MTU to populate the ARP cache, then run the existing test.  That being said, I haven't conclusively proven it is an ARP problem - ```esxcli network ip neighbor list``` doesn't show the vmotion interfaces or addresses for me (even in the default stack).  The other potential solution is to just remove the excessively low timeout, but I assume there was a reason for this (maybe to prune out long WAN links?)